### PR TITLE
Switch to local auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,8 @@
 # Database Configuration
 DATABASE_URL=postgresql://username:password@localhost:5432/skillmate
 
-# Authentication (Required for Replit Auth)
+# Authentication (Local)
 SESSION_SECRET=your-super-secret-session-key-here-make-it-long-and-random
-REPL_ID=your-replit-app-id
-ISSUER_URL=https://replit.com/oidc
-REPLIT_DOMAINS=your-replit-domain.replit.app
 
 # AI Integration (Required)
 OPENAI_API_KEY=sk-your-openai-api-key-here

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SkillMate is a comprehensive career development platform that provides AI-powere
 - **LinkedIn API** for profile integration
 
 ### Authentication & Security
-- **Replit Auth** with OpenID Connect
+- **Local Auth** using Passport Local strategy
 - **PostgreSQL Session Store** for secure session management
 - **OAuth 2.0** for LinkedIn integration
 - **Environment-based secrets** management
@@ -115,8 +115,6 @@ SkillMate is a comprehensive career development platform that provides AI-powere
 | `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@localhost:5432/skillmate` |
 | `SESSION_SECRET` | Secret key for session encryption | `your-super-secret-session-key-here` |
 | `OPENAI_API_KEY` | OpenAI API key for AI features | `sk-your-openai-api-key-here` |
-| `REPL_ID` | Replit application ID for auth | `your-replit-app-id` |
-| `REPLIT_DOMAINS` | Comma-separated domains for auth | `your-app.replit.app` |
 
 ### Optional Variables
 
@@ -125,16 +123,15 @@ SkillMate is a comprehensive career development platform that provides AI-powere
 | `LINKEDIN_CLIENT_ID` | LinkedIn app client ID | `your-linkedin-client-id` |
 | `LINKEDIN_CLIENT_SECRET` | LinkedIn app client secret | `your-linkedin-client-secret` |
 | `APP_URL` | Full application URL | `https://your-app-domain.com` |
-| `ISSUER_URL` | OIDC issuer URL | `https://replit.com/oidc` |
 | `NODE_ENV` | Environment mode | `development` or `production` |
 
 ## API Endpoints
 
 ### Authentication
 - `GET /api/auth/user` - Get current user information
-- `GET /api/login` - Initiate Replit authentication
-- `GET /api/logout` - Log out current user
-- `GET /api/callback` - OAuth callback endpoint
+- `POST /api/register` - Register a new user
+- `POST /api/login` - Log in with email and password
+- `POST /api/logout` - Log out current user
 
 ### Skills & Assessments
 - `GET /api/skills/assessments` - Get user skill assessments
@@ -212,11 +209,10 @@ skillmate/
 2. **Set production environment variables**
    Ensure all required environment variables are set in your production environment.
 
-3. **Deploy to Replit**
+3. **Deploy to Your Hosting Provider**
    - Push your code to a Git repository
-   - Import the repository to Replit
-   - Set up environment variables in Replit Secrets
-   - Deploy using Replit Deployments
+   - Configure environment variables on your platform
+   - Deploy using your provider's instructions
 
 ### Environment Setup for Production
 
@@ -246,5 +242,5 @@ For support, please contact [your-email@example.com] or create an issue in the G
 
 - OpenAI for providing the GPT-4o API
 - LinkedIn for profile integration capabilities
-- Replit for authentication and hosting infrastructure
+- Example hosting providers such as Vercel or Heroku
 - The open-source community for the excellent tools and libraries used in this project

--- a/replit.md
+++ b/replit.md
@@ -33,7 +33,7 @@ Preferred communication style: Simple, everyday language.
 - **Language**: TypeScript with ES modules
 - **Database**: PostgreSQL with Drizzle ORM
 - **Database Provider**: Neon Database (serverless PostgreSQL)
-- **Authentication**: Replit Auth with OpenID Connect
+- **Authentication**: Local Auth using Passport
 - **Session Management**: PostgreSQL-backed sessions using connect-pg-simple
 
 ### Key Design Decisions
@@ -44,8 +44,7 @@ Preferred communication style: Simple, everyday language.
 
 ## Key Components
 
-### Authentication System
-- **Provider**: Replit Auth with OIDC
+- **Provider**: Local strategy with Passport
 - **Session Storage**: PostgreSQL sessions table
 - **User Management**: Automatic user creation/updates from auth provider
 - **Security**: HTTP-only cookies with secure flags
@@ -87,7 +86,7 @@ Preferred communication style: Simple, everyday language.
 ## Data Flow
 
 ### User Onboarding
-1. User authenticates via Replit Auth
+1. User registers and logs in using local credentials
 2. Profile creation/update with career information
 3. Initial skill assessment or resume upload
 4. AI-powered skill gap analysis

--- a/server/localAuth.ts
+++ b/server/localAuth.ts
@@ -1,0 +1,101 @@
+import { Strategy as LocalStrategy } from 'passport-local';
+import passport from 'passport';
+import session from 'express-session';
+import type { Express, RequestHandler } from 'express';
+import connectPg from 'connect-pg-simple';
+import { storage } from './storage';
+import { nanoid } from 'nanoid';
+import crypto from 'crypto';
+
+function hashPassword(password: string) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+export function getSession() {
+  const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 1 week
+  const pgStore = connectPg(session);
+  const sessionStore = new pgStore({
+    conString: process.env.DATABASE_URL,
+    createTableIfMissing: false,
+    ttl: sessionTtl,
+    tableName: 'sessions',
+  });
+  return session({
+    secret: process.env.SESSION_SECRET!,
+    store: sessionStore,
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+      httpOnly: true,
+      secure: true,
+      maxAge: sessionTtl,
+    },
+  });
+}
+
+export async function setupAuth(app: Express) {
+  app.set('trust proxy', 1);
+  app.use(getSession());
+  app.use(passport.initialize());
+  app.use(passport.session());
+
+  passport.use(
+    new LocalStrategy({ usernameField: 'email', passwordField: 'password' }, async (email, password, done) => {
+      try {
+        const user = await storage.getUserByEmail(email);
+        if (!user) return done(null, false, { message: 'Invalid credentials' });
+        if (user.passwordHash !== hashPassword(password)) return done(null, false, { message: 'Invalid credentials' });
+        return done(null, user);
+      } catch (err) {
+        return done(err);
+      }
+    })
+  );
+
+  passport.serializeUser((user: any, cb) => cb(null, user.id));
+  passport.deserializeUser(async (id: string, cb) => {
+    const user = await storage.getUser(id);
+    cb(null, user || false);
+  });
+
+  app.post('/api/register', async (req, res, next) => {
+    try {
+      const { email, password, firstName, lastName } = req.body;
+      if (!email || !password) {
+        return res.status(400).json({ message: 'Email and password required' });
+      }
+      const existing = await storage.getUserByEmail(email);
+      if (existing) {
+        return res.status(400).json({ message: 'Email already in use' });
+      }
+      const user = await storage.upsertUser({
+        id: nanoid(),
+        email,
+        firstName,
+        lastName,
+        passwordHash: hashPassword(password),
+      });
+      req.login(user, (err) => {
+        if (err) return next(err);
+        res.json(user);
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/api/login', passport.authenticate('local'), (req, res) => {
+    res.json(req.user);
+  });
+
+  app.post('/api/logout', (req, res) => {
+    req.logout(() => {
+      res.json({ message: 'Logged out' });
+    });
+  });
+}
+
+export const isAuthenticated: RequestHandler = (req, res, next) => {
+  if (req.isAuthenticated()) return next();
+  res.status(401).json({ message: 'Unauthorized' });
+};

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import multer from "multer";
 import { storage } from "./storage";
-import { setupAuth, isAuthenticated } from "./replitAuth";
+import { setupAuth, isAuthenticated } from "./localAuth";
 import { processResumeUpload } from "./services/resumeAnalysis";
 import { 
   getPersonalizedCareerAdvice,
@@ -26,7 +26,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Auth routes
   app.get('/api/auth/user', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const user = await storage.getUser(userId);
       res.json(user);
     } catch (error) {
@@ -38,7 +38,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // User profile routes
   app.put('/api/user/profile', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const updates = req.body;
       
       const user = await storage.upsertUser({
@@ -56,7 +56,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Resume upload and analysis
   app.post('/api/resume/upload', isAuthenticated, upload.single('resume'), async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const file = req.file;
       
       if (!file) {
@@ -97,7 +97,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Skill assessment routes
   app.get('/api/skills/assessments', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const assessments = await storage.getSkillAssessments(userId);
       res.json(assessments);
     } catch (error) {
@@ -108,7 +108,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/skills/assessment', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const assessmentData = insertSkillAssessmentSchema.parse({
         ...req.body,
         userId,
@@ -124,7 +124,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/skills/gap-analysis', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       await generateSkillGapAnalysis(userId);
       
       const updatedAssessments = await storage.getSkillAssessments(userId);
@@ -141,7 +141,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Learning resources routes
   app.get('/api/resources', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const skillAssessments = await storage.getSkillAssessments(userId);
       
       if (skillAssessments.length === 0) {
@@ -161,7 +161,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Progress tracking routes
   app.get('/api/progress', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const progress = await storage.getUserProgress(userId);
       res.json(progress);
     } catch (error) {
@@ -172,7 +172,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/progress', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const progressData = insertUserProgressSchema.parse({
         ...req.body,
         userId,
@@ -189,7 +189,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Career goals routes
   app.get('/api/goals', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const goals = await storage.getCareerGoals(userId);
       res.json(goals);
     } catch (error) {
@@ -200,7 +200,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/goals', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const goalData = insertCareerGoalSchema.parse({
         ...req.body,
         userId,
@@ -217,7 +217,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // AI Career coaching routes
   app.post('/api/chat/advice', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const { question } = req.body;
       
       if (!question) {
@@ -234,7 +234,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.get('/api/chat/sessions', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const sessions = await storage.getChatSessions(userId);
       res.json(sessions);
     } catch (error) {
@@ -245,7 +245,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/chat/session', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const { messages, topic } = req.body;
       
       const session = await storage.createChatSession({
@@ -264,7 +264,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Portfolio project routes
   app.get('/api/portfolio/projects', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const projects = await storage.getPortfolioProjects(userId);
       res.json(projects);
     } catch (error) {
@@ -275,7 +275,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/portfolio/generate', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       await generateUserPortfolioProjects(userId);
       
       const projects = await storage.getPortfolioProjects(userId);
@@ -355,7 +355,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // LinkedIn Integration Routes
   app.get('/api/linkedin/auth', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const authUrl = linkedinService.generateAuthUrl(userId);
       res.json({ authUrl });
     } catch (error) {
@@ -384,7 +384,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post('/api/linkedin/sync', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const result = await linkedinService.syncUserProfile(userId);
       res.json(result);
     } catch (error) {
@@ -395,7 +395,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.get('/api/linkedin/data', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       const linkedinData = await linkedinService.getUserLinkedInData(userId);
       res.json(linkedinData);
     } catch (error) {
@@ -406,7 +406,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.delete('/api/linkedin/disconnect', isAuthenticated, async (req: any, res) => {
     try {
-      const userId = req.user.claims.sub;
+      const userId = req.user.id;
       await linkedinService.disconnectLinkedIn(userId);
       res.json({ message: "LinkedIn disconnected successfully" });
     } catch (error) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -25,9 +25,10 @@ import { db } from "./db";
 import { eq, and, desc, asc } from "drizzle-orm";
 
 export interface IStorage {
-  // User operations - mandatory for Replit Auth
+  // User operations
   getUser(id: string): Promise<User | undefined>;
   upsertUser(user: UpsertUser): Promise<User>;
+  getUserByEmail(email: string): Promise<User | undefined>;
   
   // Skill assessment operations
   getSkillAssessments(userId: string): Promise<SkillAssessment[]>;
@@ -77,6 +78,11 @@ export class DatabaseStorage implements IStorage {
         },
       })
       .returning();
+    return user;
+  }
+
+  async getUserByEmail(email: string): Promise<User | undefined> {
+    const [user] = await db.select().from(users).where(eq(users.email, email));
     return user;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -27,6 +27,7 @@ export const sessions = pgTable(
 export const users = pgTable("users", {
   id: varchar("id").primaryKey().notNull(),
   email: varchar("email").unique(),
+  passwordHash: varchar("password_hash"),
   firstName: varchar("first_name"),
   lastName: varchar("last_name"),
   profileImageUrl: varchar("profile_image_url"),


### PR DESCRIPTION
## Summary
- remove Replit auth references and switch to Passport local strategy
- add registration/login routes with hashed password storage
- document new auth flow in README and remove Replit specific notes
- update sample environment variables

## Testing
- `npm run check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_6887e0f20f388328bdd06c4b75bbebff